### PR TITLE
Solved bug causing MacOS fails

### DIFF
--- a/R/CollateData.R
+++ b/R/CollateData.R
@@ -191,6 +191,7 @@ IRFinder <- function(
         output_files = s_output[!already_exist],
         max_threads = n_threads,
         run_featureCounts = run_featureCounts,
+        overwrite_IRFinder_output = overwrite,
         verbose = verbose
     )
 }
@@ -229,7 +230,7 @@ IRFinder <- function(
 #'   obligate intronic regions (genomic regions that are introns for all 
 #'   transcripts). Note for introns that are internal to a single exon island
 #'   (i.e. akin to "known-exon" introns from IRFinder), \code{SpliceOverMax} 
-#'   uses \link[findOverlaps]{GenomicRanges} to summate competing mapped
+#'   uses \link[GenomicRanges]{findOverlaps} to summate competing mapped
 #'   splice reads.
 #' @param samples_per_block How many samples to process per thread. 
 #' @param n_threads The number of threads to use. On low

--- a/R/CollateData.R
+++ b/R/CollateData.R
@@ -116,7 +116,7 @@ Find_IRFinder_Output <- function(sample_path, ...) {
 #' A wrapper function to call NxtIRF/IRFinder
 #'
 #' This function calls IRFinder on one or more BAM files.
-#' @param bamfiles The file names of 1 or more BAM files
+#' @param bamfiles A vector containing file paths of 1 or more BAM files
 #' @param sample_names The sample names of the given BAM files. Must
 #'   be a vector of the same length as `bamfiles`
 #' @param reference_path The directory of the NxtIRF reference
@@ -130,6 +130,8 @@ Find_IRFinder_Output <- function(sample_path, ...) {
 #' @param run_featureCounts Whether this function will run 
 #'   `Rsubread::featureCounts()` on the BAM files. If so, the output will be
 #'   saved to "main.FC.Rds" in the output directory as a list object
+#' @param verbose (default FALSE) Set to `TRUE` to allow IRFinder to output
+#'   progress bars and messages
 #' @return None. `IRFinder()` will save output to `output_path`. \cr\cr
 #'   sample.txt.gz: The main IRFinder output file containing the quantitation
 #'   of IR and splice junctions, as well as QC information\cr\cr
@@ -146,17 +148,23 @@ Find_IRFinder_Output <- function(sample_path, ...) {
 #' @md
 #' @export
 IRFinder <- function(
-        bamfiles = "Unsorted.bam", 
+        bamfiles = "./Unsorted.bam", 
         sample_names = "sample1",
         reference_path = "./Reference",
         output_path = "./IRFinder_Output",
         n_threads = 1,
         overwrite = FALSE,
-        run_featureCounts = FALSE
+        run_featureCounts = FALSE,
+        verbose = FALSE
         ) {
     if(length(bamfiles) != length(sample_names)) {
         stop(paste("In IRFinder,",
             "Number of BAM files and sample names must be the same"
+        ), call. = FALSE)
+    }
+    if(!all(file.exists(bamfiles))) {
+        stop(paste("In IRFinder,",
+            "some BAMs in bamfiles do not exist"
         ), call. = FALSE)
     }
     if(!dir.exists(dirname(output_path))) {
@@ -177,12 +185,13 @@ IRFinder <- function(
         already_exist = rep(FALSE, length(bamfiles))
     }
 
-    run_IRFinder_multithreaded(
+    .run_IRFinder(
         reference_path = reference_path,
         bamfiles = bamfiles[!already_exist],
         output_files = s_output[!already_exist],
         max_threads = n_threads,
-        run_featureCounts = run_featureCounts
+        run_featureCounts = run_featureCounts,
+        verbose = verbose
     )
 }
 

--- a/R/CollateData.R
+++ b/R/CollateData.R
@@ -261,7 +261,9 @@ CollateData <- function(Experiment, reference_path, output_path,
             "IRMode must be either 'SpliceOverMax' (default) or 'SpliceMax'"
         ), call. = FALSE)
     }
-
+    N <- 8
+    dash_progress("Validating Experiment; checking COV files...", N)
+    message("Validating Experiment; checking COV files...")
     BPPARAM_mod = .validate_threads(n_threads)
     norm_output_path = .collateData_validate(Experiment, 
         reference_path, output_path)   
@@ -270,7 +272,7 @@ CollateData <- function(Experiment, reference_path, output_path,
     df.internal <- .collateData_expr(Experiment)
     jobs = .collateData_jobs(nrow(df.internal), BPPARAM_mod, samples_per_block)
     n_jobs = length(jobs)
-    N <- 7
+
     dash_progress("Compiling Sample Stats", N)
     message("Compiling Sample Stats")
     df.internal = .collateData_stats(df.internal, jobs, BPPARAM_mod)
@@ -323,6 +325,9 @@ CollateData <- function(Experiment, reference_path, output_path,
     se <- .collateData_initialise_HDF5(norm_output_path, colData, assays)
     
     .collateData_save_NxtSE(se, file.path(norm_output_path, "NxtSE.rds"))
+    if(dir.exists(file.path(norm_output_path "temp"))) {
+        file.remove(file.path(norm_output_path "temp"))
+    }
     dash_progress("NxtIRF Collation Finished", N)
     message("NxtIRF Collation Finished")
 }
@@ -438,9 +443,9 @@ MakeSE = function(collate_path, colData, RemoveOverlapping = TRUE) {
     if(!dir.exists(temp_output_path)) {
         dir.create(temp_output_path)
     }        
-    if(!dir.exists(file.path(norm_output_path, "samples"))) {
-        dir.create(file.path(norm_output_path, "samples"))
-    }
+    # if(!dir.exists(file.path(norm_output_path, "samples"))) {
+        # dir.create(file.path(norm_output_path, "samples"))
+    # }
     if(!dir.exists(file.path(norm_output_path, "annotation"))) {
         dir.create(file.path(norm_output_path, "annotation"))
     }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -25,8 +25,8 @@ IRF_gunzip_DF <- function(s_in, s_header_begin) {
     .Call(`_NxtIRF_IRF_gunzip_DF`, s_in, s_header_begin)
 }
 
-IRF_main <- function(bam_file, reference_file, output_file) {
-    .Call(`_NxtIRF_IRF_main`, bam_file, reference_file, output_file)
+IRF_main <- function(bam_file, reference_file, output_file, verbose = TRUE) {
+    .Call(`_NxtIRF_IRF_main`, bam_file, reference_file, output_file, verbose)
 }
 
 IRF_main_multithreaded <- function(reference_file, bam_files, output_files, max_threads) {

--- a/R/dash_utils.R
+++ b/R/dash_utils.R
@@ -139,7 +139,7 @@ plot_view_ref_fn <- function(view_chr, view_start, view_end,
             get("transcript_id") %in% selected_transcripts |
             get("transcript_name") %in% selected_transcripts]
     }
-    message(paste(nrow(transcripts.DT), " transcripts"))
+    # message(paste(nrow(transcripts.DT), " transcripts"))
 
     screen.DT = elems[
         get("transcript_id") %in% transcripts.DT$transcript_id &
@@ -374,7 +374,7 @@ plot_cov_fn <- function(view_chr, view_start, view_end, view_strand,
                         view_chr, view_start, view_end, view_strand))
                     # bin anything with cur_zoom > 5
                     df = bin_df(df, max(1, 3^(cur_zoom - 5)))
-                    message(paste("Group GetCoverage performed for", condition))
+                    # message(paste("Group GetCoverage performed for", condition))
                     for(todo in seq_len(length(samples))) {
                         df[, samples[todo]] = 
                             df[, samples[todo]] / event_norms[todo]
@@ -525,7 +525,7 @@ plot_cov_fn <- function(view_chr, view_start, view_end, view_strand,
     if(t_test == TRUE && !is.null(fac) && length(unique(fac)) == 2) {
         fac = factor(fac)
         t_test = genefilter::rowttests(data.t_test[, -1], fac)
-        message(paste("rowttests performed for", condition))
+        # message(paste("rowttests performed for", condition))
 
         DT = data.table(x = data.t_test[, 1])
         DT[, c("t_stat") := -log10(t_test$p.value)]
@@ -612,7 +612,7 @@ plot_cov_fn <- function(view_chr, view_start, view_end, view_strand,
     # ggplot equivalent: list of ggplots. 
     # Allows advanced end-users to apply final edits to ggplots
     
-    message("Cov Plot finished")
+    # message("Cov Plot finished")
     return(list(ggplot = gp_track, final_plot = final_plot))
 
 }

--- a/R/globals.R
+++ b/R/globals.R
@@ -1,5 +1,7 @@
 globalVariables(c(":=","."))
 
+buildref_version <- "0.99.0"
+
 is.nan.data.frame <- function(x) do.call(cbind, lapply(x, is.nan))
 
 is_valid <- function(x) {

--- a/man/CollateData.Rd
+++ b/man/CollateData.Rd
@@ -41,7 +41,7 @@ islands are contiguous regions covered by exons from any transcript
 obligate intronic regions (genomic regions that are introns for all
 transcripts). Note for introns that are internal to a single exon island
 (i.e. akin to "known-exon" introns from IRFinder), \code{SpliceOverMax}
-uses \link[findOverlaps]{GenomicRanges} to summate competing mapped
+uses \link[GenomicRanges]{findOverlaps} to summate competing mapped
 splice reads.}
 
 \item{samples_per_block}{How many samples to process per thread.}

--- a/man/IRFinder.Rd
+++ b/man/IRFinder.Rd
@@ -5,17 +5,18 @@
 \title{A wrapper function to call NxtIRF/IRFinder}
 \usage{
 IRFinder(
-  bamfiles = "Unsorted.bam",
+  bamfiles = "./Unsorted.bam",
   sample_names = "sample1",
   reference_path = "./Reference",
   output_path = "./IRFinder_Output",
   n_threads = 1,
   overwrite = FALSE,
-  run_featureCounts = FALSE
+  run_featureCounts = FALSE,
+  verbose = FALSE
 )
 }
 \arguments{
-\item{bamfiles}{The file names of 1 or more BAM files}
+\item{bamfiles}{A vector containing file paths of 1 or more BAM files}
 
 \item{sample_names}{The sample names of the given BAM files. Must
 be a vector of the same length as \code{bamfiles}}
@@ -35,6 +36,9 @@ will not attempt to re-run.}
 \item{run_featureCounts}{Whether this function will run
 \code{Rsubread::featureCounts()} on the BAM files. If so, the output will be
 saved to "main.FC.Rds" in the output directory as a list object}
+
+\item{verbose}{(default FALSE) Set to \code{TRUE} to allow IRFinder to output
+progress bars and messages}
 }
 \value{
 None. \code{IRFinder()} will save output to \code{output_path}. \cr\cr

--- a/src/BAM2blocks.cpp
+++ b/src/BAM2blocks.cpp
@@ -243,7 +243,7 @@ unsigned int BAM2blocks::processSingle(bam_read_core * read1) {
 
 
 
-int BAM2blocks::processAll(std::string& output, bool threaded) {
+int BAM2blocks::processAll(std::string& output, bool verbose) {
 
 	unsigned long long totalNucleotides = 0;
 	unsigned long j = 0;
@@ -254,7 +254,7 @@ int BAM2blocks::processAll(std::string& output, bool threaded) {
     std::ostringstream oss;
 #ifndef GALAXY
   uint64_t prev_bam_pos = IN->tellg();	// For progress bar
-	Progress p(IN->IS_LENGTH, !threaded);
+	Progress p(IN->IS_LENGTH, verbose);
 
 #endif
 	while(1) {
@@ -340,9 +340,11 @@ int BAM2blocks::processAll(std::string& output, bool threaded) {
       }
     }
 #ifndef GALAXY
-		if(threaded == false) {
-			p.increment((unsigned long)(IN->tellg() - prev_bam_pos));		
-			prev_bam_pos = IN->tellg();
+		if(verbose) {
+			if ( (cPairedReads + cSingleReads) % 1000000 == 0 ) {
+				p.increment((unsigned long)(IN->tellg() - prev_bam_pos));		
+				prev_bam_pos = IN->tellg();				
+			}
 		}
 #endif
 	}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -78,15 +78,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // IRF_main
-int IRF_main(std::string bam_file, std::string reference_file, std::string output_file);
-RcppExport SEXP _NxtIRF_IRF_main(SEXP bam_fileSEXP, SEXP reference_fileSEXP, SEXP output_fileSEXP) {
+int IRF_main(std::string bam_file, std::string reference_file, std::string output_file, bool verbose);
+RcppExport SEXP _NxtIRF_IRF_main(SEXP bam_fileSEXP, SEXP reference_fileSEXP, SEXP output_fileSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< std::string >::type bam_file(bam_fileSEXP);
     Rcpp::traits::input_parameter< std::string >::type reference_file(reference_fileSEXP);
     Rcpp::traits::input_parameter< std::string >::type output_file(output_fileSEXP);
-    rcpp_result_gen = Rcpp::wrap(IRF_main(bam_file, reference_file, output_file));
+    Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
+    rcpp_result_gen = Rcpp::wrap(IRF_main(bam_file, reference_file, output_file, verbose));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -141,7 +142,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_NxtIRF_IRF_RLEList_From_Cov", (DL_FUNC) &_NxtIRF_IRF_RLEList_From_Cov, 2},
     {"_NxtIRF_IRF_gunzip", (DL_FUNC) &_NxtIRF_IRF_gunzip, 2},
     {"_NxtIRF_IRF_gunzip_DF", (DL_FUNC) &_NxtIRF_IRF_gunzip_DF, 2},
-    {"_NxtIRF_IRF_main", (DL_FUNC) &_NxtIRF_IRF_main, 3},
+    {"_NxtIRF_IRF_main", (DL_FUNC) &_NxtIRF_IRF_main, 4},
     {"_NxtIRF_IRF_main_multithreaded", (DL_FUNC) &_NxtIRF_IRF_main_multithreaded, 4},
     {"_NxtIRF_IRF_GenerateMappabilityReads", (DL_FUNC) &_NxtIRF_IRF_GenerateMappabilityReads, 5},
     {"_NxtIRF_IRF_GenerateMappabilityRegions", (DL_FUNC) &_NxtIRF_IRF_GenerateMappabilityRegions, 4},


### PR DESCRIPTION
Problem is that IRFinder reference for junctions run into undefined behaviour after the last line is read. Occasionally there would be output from the istringstream.

Correction is to put a discrete EOF marker when the reference is built.

Additional modifications:
- "verbose" argument to IRFinder - FALSE by default to remove progress bars (would not work in multi-threading anyway)
_ IRFinder progress bar updates after every 1 million reads
- IRFinder multi df from gz: skips searching for key string in the middle of databases (as defined by contiguous blocks of non-zero-length lines)
_ R/IRFinder checks output files are produced after C/IRFinder is run
- BuildReference: Added versioning which is checked prior to running C/IRFinder
- BuildReference: Changed the search char from ">" to "#" (to avoid being assumed as FASTA files by e.g. Galaxy)
- BuildReference / CollateData: Removed dependency on data.table::fread from reading gzipped databases (for now)
- Plot_Coverage: Disabled debug messages